### PR TITLE
feat: add docs on typed query snapshot

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -100,6 +100,8 @@ export interface TypedQueryDocumentSnapshot<T extends firestore.DocumentData>
 
 export interface TypedQuerySnapshot<T extends firestore.DocumentData>
   extends firestore.QuerySnapshot {
+  readonly docs: TypedQueryDocumentSnapshot<T>[];
+
   docChanges(): TypedDocumentChange<T>[];
 
   forEach(


### PR DESCRIPTION
i'd like to write the code below, so I need docs property.

```js
AuthorCollection.get().then(snapshot => {
  for (const doc of snapshot.docs) {
    await hoge(doc.data());
  };
});
```